### PR TITLE
feat: set MPPT settings via webpanel

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,6 +191,134 @@ bool resetCounter(bool count)
   return true;
 }
 
+bool validMpptDevice(uint8_t device)
+{
+  return device >= 1 && device <= _settings.data.deviceQuantity;
+}
+
+uint8_t readMpptSettings(uint8_t device, uint16_t *values)
+{
+  epnode.setSlaveId(device);
+  epnode.clearResponseBuffer();
+  uint8_t status = epnode.readHoldingRegisters(DEVICE_SETTINGS, DEVICE_SETTINGS_CNT);
+  if (status == epnode.ku8MBSuccess)
+  {
+    for (uint8_t index = 0; index < DEVICE_SETTINGS_CNT; index++)
+      values[index] = epnode.getResponseBuffer(index);
+  }
+  return status;
+}
+
+bool mpptSettingsMatch(const uint16_t *expected, const uint16_t *actual)
+{
+  for (uint8_t index = 0; index < DEVICE_SETTINGS_CNT; index++)
+  {
+    if (expected[index] != actual[index])
+      return false;
+  }
+  return true;
+}
+
+uint8_t writeMpptSettings(uint8_t device, const uint16_t *values)
+{
+  epnode.setSlaveId(device);
+  epnode.clearTransmitBuffer();
+  for (uint8_t index = 0; index < DEVICE_SETTINGS_CNT; index++)
+    epnode.setTransmitBuffer(index, values[index]);
+  return epnode.writeMultipleRegisters(DEVICE_SETTINGS, DEVICE_SETTINGS_CNT);
+}
+
+uint8_t writeAndVerifyMpptSettings(uint8_t device, const uint16_t *values, uint16_t *readBack,
+                                   uint8_t &writeStatus, uint8_t &readStatus)
+{
+  uint16_t previousTimeout = epnode.getResponseTimeout();
+  epnode.setResponseTimeout(500);
+  writeStatus = writeMpptSettings(device, values);
+  delay(200);
+  readStatus = readMpptSettings(device, readBack);
+
+  if (readStatus == epnode.ku8MBSuccess && mpptSettingsMatch(values, readBack))
+  {
+    epnode.setResponseTimeout(previousTimeout);
+    return 0;
+  }
+
+  if (writeStatus == epnode.ku8MBResponseTimedOut || writeStatus == epnode.ku8MBInvalidCRC)
+  {
+    delay(250);
+    writeStatus = writeMpptSettings(device, values);
+    delay(200);
+    readStatus = readMpptSettings(device, readBack);
+  }
+
+  epnode.setResponseTimeout(previousTimeout);
+  if (readStatus != epnode.ku8MBSuccess)
+    return 1;
+  return mpptSettingsMatch(values, readBack) ? 0 : 2;
+}
+
+void updateMpptSettingsJson(uint8_t device, const uint16_t *values)
+{
+  JsonObject deviceData = liveJson["EP_" + String(device)]["DeviceData"];
+  deviceData["BATTERY_TYPE"] = values[0] < (sizeof batt_type / sizeof batt_type[0]) ? batt_type[values[0]] : "Unknown";
+  deviceData["BATTERY_CAPACITY"] = values[1];
+  deviceData["TEMPERATURE_COMPENSATION"] = values[2] / 100.f;
+  deviceData["HIGH_VOLT_DISCONNECT"] = values[3] / 100.f;
+  deviceData["CHARGING_LIMIT_VOLTS"] = values[4] / 100.f;
+  deviceData["OVER_VOLTS_RECONNECT"] = values[5] / 100.f;
+  deviceData["EQUALIZATION_VOLTS"] = values[6] / 100.f;
+  deviceData["BOOST_VOLTS"] = values[7] / 100.f;
+  deviceData["FLOAT_VOLTS"] = values[8] / 100.f;
+  deviceData["BOOST_RECONNECT_VOLTS"] = values[9] / 100.f;
+  deviceData["LOW_VOLTS_RECONNECT"] = values[10] / 100.f;
+  deviceData["UNDER_VOLTS_RECOVER"] = values[11] / 100.f;
+  deviceData["UNDER_VOLTS_WARNING"] = values[12] / 100.f;
+  deviceData["LOW_VOLTS_DISCONNECT"] = values[13] / 100.f;
+  deviceData["DISCHARGING_LIMIT_VOLTS"] = values[14] / 100.f;
+}
+
+void sendMpptSettingsResponse(AsyncWebServerRequest *request, uint16_t statusCode, uint8_t device,
+                              const uint16_t *values, const String &message)
+{
+  JsonDocument document;
+  document["ok"] = statusCode == 200;
+  document["device"] = device;
+  document["deviceQuantity"] = _settings.data.deviceQuantity;
+  document["message"] = message;
+  if (values != nullptr)
+  {
+    JsonArray registerValues = document["values"].to<JsonArray>();
+    for (uint8_t index = 0; index < DEVICE_SETTINGS_CNT; index++)
+      registerValues.add(values[index]);
+  }
+
+  String body;
+  serializeJson(document, body);
+  request->send(statusCode, "application/json", body);
+}
+
+bool parseMpptSetting(AsyncWebServerRequest *request, uint8_t index, uint16_t scale, uint16_t maximum,
+                      uint16_t &value)
+{
+  String parameterName = "e" + String(index + 1);
+  if (!request->hasParam(parameterName, true))
+    return false;
+
+  String input = request->getParam(parameterName, true)->value();
+  char *end = nullptr;
+  double parsed = strtod(input.c_str(), &end);
+  if (input.length() == 0 || end == input.c_str() || *end != '\0' || !isfinite(parsed) || parsed < 0)
+    return false;
+
+  double scaled = parsed * scale;
+  double rounded = round(scaled);
+  if (scaled > maximum || fabs(scaled - rounded) > 0.001)
+    return false;
+
+  value = (uint16_t)rounded;
+  return true;
+}
+
 void setup()
 {
   _settings.load();
@@ -348,6 +476,220 @@ void setup()
                 if(strlen(_settings.data.httpUser) > 0 && !request->authenticate(_settings.data.httpUser, _settings.data.httpPass)) return request->requestAuthentication();
       AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", HTML_SETTINGS_EDIT, htmlProcessor);
       request->send(response); });
+
+    server.on("/mpptsettings", HTTP_GET, [](AsyncWebServerRequest *request)
+              {
+                if(strlen(_settings.data.httpUser) > 0 && !request->authenticate(_settings.data.httpUser, _settings.data.httpPass)) return request->requestAuthentication();
+                AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", HTML_MPPT_SETTINGS, htmlProcessor);
+                request->send(response); });
+
+    server.on("/mpptsettingsjson", HTTP_GET, [](AsyncWebServerRequest *request)
+              {
+                if(strlen(_settings.data.httpUser) > 0 && !request->authenticate(_settings.data.httpUser, _settings.data.httpPass)) return request->requestAuthentication();
+                uint8_t device = request->hasParam("device") ? request->getParam("device")->value().toInt() : 1;
+                if (!validMpptDevice(device))
+                {
+                  sendMpptSettingsResponse(request, 400, device, nullptr, "Invalid MPPT device number");
+                  return;
+                }
+
+                uint16_t values[DEVICE_SETTINGS_CNT];
+                workerCanRun = false;
+                uint8_t status = readMpptSettings(device, values);
+                workerCanRun = true;
+                if (status != epnode.ku8MBSuccess)
+                {
+                  sendMpptSettingsResponse(request, 502, device, nullptr, "Modbus read failed (code " + String(status) + ")");
+                  return;
+                }
+
+                updateMpptSettingsJson(device, values);
+                sendMpptSettingsResponse(request, 200, device, values, "Settings read successfully");
+              });
+
+    server.on("/mpptsettingsapply", HTTP_POST, [](AsyncWebServerRequest *request)
+              {
+                if(strlen(_settings.data.httpUser) > 0 && !request->authenticate(_settings.data.httpUser, _settings.data.httpPass)) return request->requestAuthentication();
+                uint8_t device = request->hasParam("device", true) ? request->getParam("device", true)->value().toInt() : 0;
+                if (!validMpptDevice(device))
+                {
+                  sendMpptSettingsResponse(request, 400, device, nullptr, "Invalid MPPT device number");
+                  return;
+                }
+
+                uint16_t values[DEVICE_SETTINGS_CNT];
+                if (!parseMpptSetting(request, 0, 1, 3, values[0]) ||
+                    !parseMpptSetting(request, 1, 1, UINT16_MAX, values[1]))
+                {
+                  sendMpptSettingsResponse(request, 400, device, nullptr, "E1 or E2 contains an invalid value");
+                  return;
+                }
+                for (uint8_t index = 2; index < DEVICE_SETTINGS_CNT; index++)
+                {
+                  uint16_t maximum = index == 2 ? 900 : UINT16_MAX;
+                  if (!parseMpptSetting(request, index, 100, maximum, values[index]))
+                  {
+                    sendMpptSettingsResponse(request, 400, device, nullptr, "E" + String(index + 1) + " contains an invalid value");
+                    return;
+                  }
+                }
+                if (!(values[3] > values[4] && values[4] > values[6] && values[6] > values[7] &&
+                      values[7] > values[8] && values[8] > values[9]))
+                {
+                  sendMpptSettingsResponse(request, 400, device, nullptr,
+                                           "Required: E4 > E5 > E7 > E8 > E9 > E10");
+                  return;
+                }
+                if (!(values[11] > values[12] && values[12] > values[13] && values[13] > values[14]))
+                {
+                  sendMpptSettingsResponse(request, 400, device, nullptr,
+                                           "Required: E12 > E13 > E14 > E15");
+                  return;
+                }
+                if (values[3] <= values[5])
+                {
+                  sendMpptSettingsResponse(request, 400, device, nullptr, "Required: E4 > E6");
+                  return;
+                }
+                if (values[10] <= values[13])
+                {
+                  sendMpptSettingsResponse(request, 400, device, nullptr, "Required: E11 > E14");
+                  return;
+                }
+                workerCanRun = false;
+                uint16_t readBack[DEVICE_SETTINGS_CNT];
+                uint8_t writeStatus;
+                uint8_t readStatus;
+                uint8_t verifyStatus = writeAndVerifyMpptSettings(device, values, readBack, writeStatus, readStatus);
+                workerCanRun = true;
+                if (verifyStatus == 1)
+                {
+                  sendMpptSettingsResponse(request, 502, device, nullptr,
+                                           "Modbus write acknowledgement code " + String(writeStatus) +
+                                               "; read-back failed with code " + String(readStatus));
+                  return;
+                }
+
+                updateMpptSettingsJson(device, readBack);
+                if (verifyStatus == 2)
+                {
+                  sendMpptSettingsResponse(request, 409, device, readBack,
+                                           "The controller rejected or changed one or more values; actual values were reloaded (write code " +
+                                               String(writeStatus) + ")");
+                  return;
+                }
+
+                mqtttimer = 0;
+                String message = writeStatus == epnode.ku8MBSuccess
+                                     ? "MPPT settings applied and verified"
+                                     : "MPPT settings applied and verified despite write acknowledgement error " + String(writeStatus);
+                sendMpptSettingsResponse(request, 200, device, readBack, message);
+              });
+
+    server.on("/mpptsettingsclone", HTTP_POST, [](AsyncWebServerRequest *request)
+              {
+                if(strlen(_settings.data.httpUser) > 0 && !request->authenticate(_settings.data.httpUser, _settings.data.httpPass)) return request->requestAuthentication();
+                uint8_t source = request->hasParam("source", true) ? request->getParam("source", true)->value().toInt() : 0;
+                String targetList = request->hasParam("targets", true) ? request->getParam("targets", true)->value() : "";
+                if (!validMpptDevice(source))
+                {
+                  sendMpptSettingsResponse(request, 400, source, nullptr, "Invalid source MPPT device number");
+                  return;
+                }
+
+                bool selected[10] = {false};
+                uint8_t targetCount = 0;
+                unsigned int start = 0;
+                while (start < targetList.length())
+                {
+                  int comma = targetList.indexOf(',', start);
+                  String token = comma < 0 ? targetList.substring(start) : targetList.substring(start, comma);
+                  token.trim();
+                  uint8_t target = token.toInt();
+                  if (token.length() == 0 || !validMpptDevice(target) || target >= (sizeof selected / sizeof selected[0]) || target == source)
+                  {
+                    sendMpptSettingsResponse(request, 400, source, nullptr, "Invalid clone target list");
+                    return;
+                  }
+                  if (!selected[target])
+                  {
+                    selected[target] = true;
+                    targetCount++;
+                  }
+                  if (comma < 0)
+                    break;
+                  start = comma + 1;
+                }
+                if (targetCount == 0)
+                {
+                  sendMpptSettingsResponse(request, 400, source, nullptr, "Select at least one other MPPT device");
+                  return;
+                }
+
+                workerCanRun = false;
+                uint16_t sourceValues[DEVICE_SETTINGS_CNT];
+                uint16_t previousTimeout = epnode.getResponseTimeout();
+                epnode.setResponseTimeout(500);
+                uint8_t sourceReadStatus = readMpptSettings(source, sourceValues);
+                epnode.setResponseTimeout(previousTimeout);
+                if (sourceReadStatus != epnode.ku8MBSuccess)
+                {
+                  workerCanRun = true;
+                  sendMpptSettingsResponse(request, 502, source, nullptr,
+                                           "Could not read source MPPT settings (code " + String(sourceReadStatus) + ")");
+                  return;
+                }
+                updateMpptSettingsJson(source, sourceValues);
+
+                JsonDocument document;
+                document["source"] = source;
+                document["deviceQuantity"] = _settings.data.deviceQuantity;
+                JsonArray results = document["results"].to<JsonArray>();
+                uint8_t successCount = 0;
+
+                for (uint8_t target = 1; target <= _settings.data.deviceQuantity && target < (sizeof selected / sizeof selected[0]); target++)
+                {
+                  if (!selected[target])
+                    continue;
+
+                  uint16_t readBack[DEVICE_SETTINGS_CNT];
+                  uint8_t writeStatus;
+                  uint8_t readStatus;
+                  uint8_t verifyStatus = writeAndVerifyMpptSettings(target, sourceValues, readBack, writeStatus, readStatus);
+                  JsonObject targetResult = results.add<JsonObject>();
+                  targetResult["device"] = target;
+                  targetResult["writeCode"] = writeStatus;
+                  targetResult["readCode"] = readStatus;
+                  targetResult["ok"] = verifyStatus == 0;
+
+                  if (verifyStatus == 0)
+                  {
+                    successCount++;
+                    updateMpptSettingsJson(target, readBack);
+                    targetResult["message"] = writeStatus == epnode.ku8MBSuccess
+                                                  ? "Cloned and verified"
+                                                  : "Cloned and verified despite acknowledgement error";
+                  }
+                  else if (verifyStatus == 1)
+                  {
+                    targetResult["message"] = "Read-back failed";
+                  }
+                  else
+                  {
+                    updateMpptSettingsJson(target, readBack);
+                    targetResult["message"] = "Controller rejected or changed values";
+                  }
+                  delay(100);
+                }
+
+                workerCanRun = true;
+                mqtttimer = 0;
+                document["ok"] = successCount == targetCount;
+                document["message"] = String(successCount) + " of " + String(targetCount) + " target devices cloned successfully";
+                String body;
+                serializeJson(document, body);
+                request->send(200, "application/json", body);
+              });
 
     server.on("/settingssave", HTTP_POST, [](AsyncWebServerRequest *request)
               {

--- a/src/webpages/HTML_MPPT_SETTINGS.html
+++ b/src/webpages/HTML_MPPT_SETTINGS.html
@@ -1,0 +1,246 @@
+%pre_head_template%
+<figure class="text-center">
+  <h1>MPPT Settings</h1>
+  <p class="text-body-secondary">Registers E1-E15</p>
+</figure>
+
+<div id="status" class="alert alert-info" role="alert">Reading settings from the controller...</div>
+
+<form id="mpptForm">
+  <div class="input-group mb-3">
+    <span class="input-group-text w-50">MPPT device</span>
+    <select class="form-select" id="device" name="device"></select>
+    <button class="btn btn-outline-secondary" type="button" id="reloadButton">Reload</button>
+  </div>
+
+  <div id="fields"></div>
+
+  <div class="alert alert-warning small" role="alert">
+    Changing charge voltages can damage a battery. Check the battery manufacturer's limits first.
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">Clone current hardware settings</h5>
+      <p class="card-text small">Copy the selected source device's actual E1-E15 values to these devices:</p>
+      <div id="cloneTargets" class="mb-3"></div>
+      <button class="btn btn-warning w-100" id="cloneButton" type="button" disabled>Clone to selected devices</button>
+    </div>
+  </div>
+
+  <div class="d-grid gap-2">
+    <button class="btn btn-primary" id="applyButton" type="submit" disabled>Apply and verify</button>
+    <a class="btn btn-primary" href="/settings" role="button">Back</a>
+  </div>
+</form>
+
+<script>
+  const definitions = [
+    { label: 'E1 Battery type', unit: '', type: 'select' },
+    { label: 'E2 Battery capacity', unit: 'Ah', step: '1' },
+    { label: 'E3 Temperature compensation', unit: 'mV/C/2V', step: '0.01', max: '9' },
+    { label: 'E4 High voltage disconnect', unit: 'V', step: '0.01' },
+    { label: 'E5 Charging limit voltage', unit: 'V', step: '0.01' },
+    { label: 'E6 Over voltage reconnect', unit: 'V', step: '0.01' },
+    { label: 'E7 Equalization voltage', unit: 'V', step: '0.01' },
+    { label: 'E8 Boost voltage', unit: 'V', step: '0.01' },
+    { label: 'E9 Float voltage', unit: 'V', step: '0.01' },
+    { label: 'E10 Boost reconnect voltage', unit: 'V', step: '0.01' },
+    { label: 'E11 Low voltage reconnect', unit: 'V', step: '0.01' },
+    { label: 'E12 Under voltage recover', unit: 'V', step: '0.01' },
+    { label: 'E13 Under voltage warning', unit: 'V', step: '0.01' },
+    { label: 'E14 Low voltage disconnect', unit: 'V', step: '0.01' },
+    { label: 'E15 Discharging limit voltage', unit: 'V', step: '0.01' }
+  ];
+
+  const fields = document.getElementById('fields');
+  const form = document.getElementById('mpptForm');
+  const deviceSelect = document.getElementById('device');
+  const applyButton = document.getElementById('applyButton');
+  const reloadButton = document.getElementById('reloadButton');
+  const cloneButton = document.getElementById('cloneButton');
+  const cloneTargets = document.getElementById('cloneTargets');
+  const statusBox = document.getElementById('status');
+  let settingsLoaded = false;
+  let deviceQuantity = 1;
+
+  definitions.forEach((definition, index) => {
+    const group = document.createElement('div');
+    group.className = 'input-group mb-2';
+
+    const label = document.createElement('label');
+    label.className = 'input-group-text w-50';
+    label.htmlFor = 'e' + (index + 1);
+    label.textContent = definition.label;
+    group.appendChild(label);
+
+    let input;
+    if (definition.type === 'select') {
+      input = document.createElement('select');
+      ['User', 'Sealed', 'GEL', 'Flooded'].forEach((name, value) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = value + ' - ' + name;
+        input.appendChild(option);
+      });
+    } else {
+      input = document.createElement('input');
+      input.type = 'number';
+      input.min = '0';
+      input.max = definition.max || (definition.step === '1' ? '65535' : '655.35');
+      input.step = definition.step;
+      input.required = true;
+    }
+    input.className = 'form-control';
+    input.id = 'e' + (index + 1);
+    input.name = input.id;
+    group.appendChild(input);
+
+    if (definition.unit) {
+      const unit = document.createElement('span');
+      unit.className = 'input-group-text';
+      unit.textContent = definition.unit;
+      group.appendChild(unit);
+    }
+    fields.appendChild(group);
+  });
+
+  function showStatus(message, style) {
+    statusBox.className = 'alert alert-' + style;
+    statusBox.textContent = message;
+  }
+
+  function setBusy(busy) {
+    applyButton.disabled = busy || !settingsLoaded;
+    reloadButton.disabled = busy;
+    deviceSelect.disabled = busy;
+    cloneButton.disabled = busy || !settingsLoaded || selectedCloneTargets().length === 0;
+    cloneTargets.querySelectorAll('input').forEach(input => input.disabled = busy);
+  }
+
+  function selectedCloneTargets() {
+    return Array.from(cloneTargets.querySelectorAll('input:checked')).map(input => input.value);
+  }
+
+  function renderCloneTargets() {
+    cloneTargets.innerHTML = '';
+    for (let number = 1; number <= deviceQuantity; number++) {
+      if (String(number) === String(deviceSelect.value)) continue;
+      const wrapper = document.createElement('div');
+      wrapper.className = 'form-check';
+      const input = document.createElement('input');
+      input.className = 'form-check-input';
+      input.type = 'checkbox';
+      input.value = number;
+      input.id = 'cloneTarget' + number;
+      input.addEventListener('change', () => setBusy(false));
+      const label = document.createElement('label');
+      label.className = 'form-check-label';
+      label.htmlFor = input.id;
+      label.textContent = 'Device ' + number;
+      wrapper.appendChild(input);
+      wrapper.appendChild(label);
+      cloneTargets.appendChild(wrapper);
+    }
+    if (!cloneTargets.children.length) {
+      cloneTargets.textContent = 'No other configured devices are available.';
+    }
+    setBusy(false);
+  }
+
+  function populateValues(values) {
+    values.forEach((raw, index) => {
+      document.getElementById('e' + (index + 1)).value = index < 2 ? raw : (raw / 100).toFixed(2);
+    });
+  }
+
+  async function loadSettings() {
+    settingsLoaded = false;
+    setBusy(true);
+    showStatus('Reading settings from MPPT device ' + deviceSelect.value + '...', 'info');
+    try {
+      const response = await fetch('/mpptsettingsjson?device=' + encodeURIComponent(deviceSelect.value), { cache: 'no-store' });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.message || 'Unable to read MPPT settings');
+
+      deviceQuantity = data.deviceQuantity;
+      while (deviceSelect.options.length < deviceQuantity) {
+        const number = deviceSelect.options.length + 1;
+        deviceSelect.add(new Option('Device ' + number, number));
+      }
+      while (deviceSelect.options.length > deviceQuantity) {
+        deviceSelect.remove(deviceSelect.options.length - 1);
+      }
+      populateValues(data.values);
+      settingsLoaded = true;
+      renderCloneTargets();
+      showStatus(data.message, 'success');
+    } catch (error) {
+      showStatus(error.message, 'danger');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  form.addEventListener('submit', async event => {
+    event.preventDefault();
+    if (!form.reportValidity()) return;
+    if (!window.confirm('Write all E1-E15 settings to MPPT device ' + deviceSelect.value + '?')) return;
+
+    const formData = new FormData(form);
+    setBusy(true);
+    showStatus('Writing and verifying MPPT settings...', 'warning');
+    try {
+      const response = await fetch('/mpptsettingsapply', {
+        method: 'POST',
+        body: formData
+      });
+      const data = await response.json();
+      if (data.values) populateValues(data.values);
+      if (!response.ok) throw new Error(data.message || 'Unable to apply MPPT settings');
+      settingsLoaded = true;
+      showStatus(data.message, 'success');
+    } catch (error) {
+      showStatus(error.message, 'danger');
+    } finally {
+      setBusy(false);
+    }
+  });
+
+  cloneButton.addEventListener('click', async () => {
+    const targets = selectedCloneTargets();
+    if (!targets.length) return;
+    const source = deviceSelect.value;
+    if (!window.confirm('Clone the actual E1-E15 settings from device ' + source + ' to device(s) ' + targets.join(', ') + '?')) return;
+
+    const formData = new FormData();
+    formData.append('source', source);
+    formData.append('targets', targets.join(','));
+    setBusy(true);
+    showStatus('Cloning settings from device ' + source + '...', 'warning');
+    try {
+      const response = await fetch('/mpptsettingsclone', { method: 'POST', body: formData });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.message || 'Unable to clone MPPT settings');
+      const details = (data.results || []).map(result =>
+        'Device ' + result.device + ': ' + result.message +
+        ' (write ' + result.writeCode + ', read ' + result.readCode + ')'
+      ).join(' | ');
+      showStatus(data.message + (details ? ' — ' + details : ''), data.ok ? 'success' : 'warning');
+    } catch (error) {
+      showStatus(error.message, 'danger');
+    } finally {
+      setBusy(false);
+    }
+  });
+
+  reloadButton.addEventListener('click', loadSettings);
+  deviceSelect.addEventListener('change', () => {
+    renderCloneTargets();
+    loadSettings();
+  });
+  deviceSelect.add(new Option('Device 1', 1));
+  loadSettings();
+</script>
+%pre_foot_template%
+<p hidden></p>

--- a/src/webpages/HTML_SETTINGS.html
+++ b/src/webpages/HTML_SETTINGS.html
@@ -19,6 +19,7 @@
     </div>
   </div>
   <a class="btn btn-primary" href="/settingsedit" role="button">Configure</a>
+  <a class="btn btn-primary" href="/mpptsettings" role="button">MPPT Settings</a>
   <a class="btn btn-primary" onclick='SendDateString();' role="button">Set device time from computer</a>
   <a class="btn btn-warning" href="/reboot" role="button">Reboot</a>
   <a class="btn btn-primary" href="/confirmreset" role="button">Reset ESP</a>


### PR DESCRIPTION
Added the ability to read and write registers 0x9000-0x900E via the UI and cloning of those values to other devices on the same bus.
Validation errors are returned to the user like: E8 > E9

Register names and addresses from:
[EpeverBSeriesControllerProtocolV2.3.pdf](https://github.com/user-attachments/files/29138501/EpeverBSeriesControllerProtocolV2.3.pdf)

Tested with Tracer 5420AN